### PR TITLE
Fix/gradle run, SpringBootNewProject version pick 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,21 @@ To use this feature, simply run the following command in Neovim:
 ```vim
 :SpringBootNewProject
 ```
-
 This will initiate the process of creating a new Spring Boot project tailored to your specifications.
+
+This functionality requires `Spring Boot CLI` tool.
+It can be installed using either SDKMAN or Homebrew:
+### SDKMAN
+```sh
+$ sdk install springboot
+$ spring --version
+Spring CLI v3.3.4
+```
+### Homebrew
+```sh
+$ brew tap spring-io/tap
+$ brew install spring-boot
+```
 
 ## Contributing
 

--- a/lua/create_springboot_project.lua
+++ b/lua/create_springboot_project.lua
@@ -101,7 +101,7 @@ local function get_boot_version(data_available)
 	local version_available = list_to_string(data_available, false)
 	local options_err = list_to_string(data_available, true)
 
-	local boot_version = vim.fn.input("Enter Spring Boot Version (" .. version_available .. "): ", "3.3.1.RELEASE")
+	local boot_version = vim.fn.input("Enter Spring Boot Version (" .. version_available .. "): ", data_available[#data_available])
 	if not contains(data_available, boot_version) then
 		print("Invalid Spring Boot version. Please enter a valid version " .. options_err .. ".")
 		return ""

--- a/lua/springboot-nvim/init.lua
+++ b/lua/springboot-nvim/init.lua
@@ -25,10 +25,10 @@ local function get_run_command(args)
 	local maven_file = vim.fn.findfile("pom.xml", vim.fn.getcwd())
 	local gradle_file = vim.fn.findfile("build.gradle", vim.fn.getcwd())
 
-	if maven_file then
-		return string.format(':call jobsend(b:terminal_job_id, "mvn spring-boot:run %s \\n")', args)
-	elseif gradle_file then
-		return ':call jobsend(b:terminal_job_id, "gradle bootRun\\n")'
+	if maven_file ~= "" then
+		return string.format(':call jobsend(b:terminal_job_id, "./mvnw spring-boot:run %s \\n")', args)
+	elseif gradle_file ~= "" then
+		return ':call jobsend(b:terminal_job_id, "./gradlew bootRun\\n")'
 	else
 		return "Unknown"
 	end


### PR DESCRIPTION
Hello!
Thank you for this project and for the awesome tutorial on YouTube about setup NVim for Java development! Was looking for something similar for quite a long time.

#### This PR contains some tiny changes:
#### Fix for Gradle
Lua empty string is considered as `True`, so Gradle branch in the `get_run_command` was never reachable.
Also I'd like to suggest to use wrappers for both Maven and Gradle - I assume most SpringBoot project will have them.
#### Fix for `SpringBootNewProject.get_boot_version`
Currently version of the SpringBoot is hardcoded (3.3.1.RELEASE) and is not available on the site. I suggest to just pick one from the available values to avoid error in case when click Enter for all default values.
#### README update
To use `:SpringBootNewProject` CLI tool needs to be installed, and it was not mentioned in the README. I thought that it would be nice to mention that for new users.

I'll be glad if some of those changes might be useful.