### PR TITLE
Improved package detection

### DIFF
--- a/lua/springboot-nvim/init.lua
+++ b/lua/springboot-nvim/init.lua
@@ -57,10 +57,19 @@ local function contains_package_info(file_path)
 		return false
 	end
 
-	local first_line = file:read("*l")
-	file:close()
+    local has_package_info = false
 
-	return first_line and first_line:find("package", 1, true) ~= nil
+    local line
+    repeat
+        line = file:read("*l")
+        if line and string.match(line, "^package") then
+            has_package_info = true
+            break
+        end
+    until not line
+
+    file:close()
+    return has_package_info
 end
 
 local function get_java_package(file_path)


### PR DESCRIPTION
Hey, 

I came across this small issue, that when java file starts with a comment, as follows:

```
/*
 * Copyright...
 */
package com.example;
```

Then `springboot-plugin` will override the content of the file with a resolved package.
So I propose scanning the whole file for the package info, instead of just the first line.

BTW thanks for creating the plugin!