### PR TITLE
Changes to improved package detection

### DIFF
--- a/lua/springboot-nvim/init.lua
+++ b/lua/springboot-nvim/init.lua
@@ -56,10 +56,10 @@ local function contains_package_info(file_path)
 	if not file then
 		return false
 	end
-    local current_position = file:seek()
-    local file_size = file:seek("end")
-    file:seek("set", current_position)
-    file:close()
+	local current_position = file:seek()
+	local file_size = file:seek("end")
+	file:seek("set", current_position)
+	file:close()
 
 	return file_size > 0
 end

--- a/lua/springboot-nvim/init.lua
+++ b/lua/springboot-nvim/init.lua
@@ -56,20 +56,12 @@ local function contains_package_info(file_path)
 	if not file then
 		return false
 	end
-
-    local has_package_info = false
-
-    local line
-    repeat
-        line = file:read("*l")
-        if line and string.match(line, "^package") then
-            has_package_info = true
-            break
-        end
-    until not line
-
+    local current_position = file:seek()
+    local file_size = file:seek("end")
+    file:seek("set", current_position)
     file:close()
-    return has_package_info
+
+	return file_size > 0
 end
 
 local function get_java_package(file_path)


### PR DESCRIPTION
I was trying to simplify the logic of the function. Is it really necessary to check for 'package' and overwrite everything in the file if the statement isn't found? Shouldn't it be easier—something like: file is empty, write the package statement; file has something inside, leave it like it is. Am i missing something?