### PR TITLE
Added check for nvim-tree plugin

### DIFF
--- a/lua/create_springboot_project.lua
+++ b/lua/create_springboot_project.lua
@@ -122,6 +122,14 @@ local function get_packaging(data_available)
 	return packaging
 end
 
+local function is_nvim_tree_available()
+	local has_nvim_tree_cmd = vim.fn.exists(":NvimTreeFindFileToggle") == 2
+
+	local has_nvim_tree_module = pcall(require, "nvim-tree")
+
+	return has_nvim_tree_cmd or has_nvim_tree_module
+end
+
 local function springboot_new_project()
 	local request = safe_request("https://start.spring.io/metadata/client")
 
@@ -195,7 +203,9 @@ local function springboot_new_project()
 		local pathJava = vim.fn.system("fd -I java src/main/java")
 
 		vim.cmd("e " .. pathJava)
-		vim.cmd(":NvimTreeFindFileToggl<CR>")
+		if is_nvim_tree_available() then
+			vim.cmd("NvimTreeFindFileToggle")
+		end
 	end
 
 	print("Project created successfully!")


### PR DESCRIPTION
## Added nvim-tree availability check 

This PR prevents error messages when creating Spring Boot projects without nvim-tree installed:

* Added `is_nvim_tree_available()` function to safely detect if nvim-tree is present
* Updated project creation workflow to only use nvim-tree when available
* Ensures clean user experience regardless of installed plugins

Previously, the plugin would try to run nvim-tree commands unconditionally, causing error messages that might confuse users into thinking the project creation failed.