### PR TITLE
Feature: pass compilation result callback function to jdtls.compile()

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ return {
     },
     config = function()
         local springboot_nvim = require("springboot-nvim")
-        springboot_nvim.setup({})
+        springboot_nvim.setup({
+            -- callback of type fun(result: table[]): nil called on JDTLS compilation result,
+            -- nil defaults to opening a quickfix list if there are errors
+            -- see :h jdtls.compile
+            on_compile_result = nil
+        })
     end
 }
 ```

--- a/lua/springboot-nvim/init.lua
+++ b/lua/springboot-nvim/init.lua
@@ -5,8 +5,10 @@ require("create_springboot_project")
 local lspconfig = require("lspconfig")
 local jdtls = require("jdtls")
 
+local on_compile_result = nil
+
 local function incremental_compile()
-	jdtls.compile("incremental")
+	jdtls.compile("incremental", on_compile_result)
 end
 
 local function is_plugin_installed(plugin)
@@ -130,7 +132,9 @@ end
 -- key mapping
 
 -- auto commands
-local function setup()
+local function setup(opts)
+	on_compile_result = opts.on_compile_result
+
 	vim.api.nvim_exec(
 		[[
     augroup JavaAutoCommands


### PR DESCRIPTION
Current behavior is to open quickfix list on every compilation error. This is annoying in large projects that often have lingering errors in the code that may or may not be a real problems, but aren't going to be fixed.

In [this commit](https://github.com/mfussenegger/nvim-jdtls/commit/baae618ccc7b6045f7d9453ea0566d1333100740) JDTLS added the ability to customize this with a callback. This PR allows to pass this callback to `jdtls.compile()`.